### PR TITLE
Hot Fix: Change location of logging middleware

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -3,18 +3,11 @@
 // Import the app from src
 import app from "./src/app";
 
-// Import morgan library for logging http requests
-import morgan from "morgan";
-
 // Read port from environment variables
 const PORT = process.env.PORT;
 
 // Read debugging mode from environment variables
 const DEBUG = process.env.DEBUG === "true" || false;
-
-// Set logging level based on debug mode and add morgan middleware to app
-const logging_level = DEBUG ? "dev" : "tiny";
-app.use(morgan(logging_level));
 
 // Have the app listen on the desired port
 const server = app.listen(PORT, () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,8 @@
 // app.ts - Creates the express app and defines routes.
 
+// Import dependencies
 import express from "express";
+import morgan from "morgan";
 
 // Import the routers for the app
 import users from "./api/users";
@@ -12,6 +14,13 @@ const app = express();
 
 // Use express json middleware for all routes
 app.use(express.json());
+
+// Set debug based on environment variables
+const DEBUG = process.env.DEBUG?.toLowerCase() === "true" || false;
+
+// Set logging level based on debug mode and add morgan middleware to app
+const logging_level = DEBUG ? "dev" : "tiny";
+app.use(morgan(logging_level));
 
 // Use the users router in the corresponding route.
 app.use("/api/v1/users", users);


### PR DESCRIPTION
Logging middleware was added at the end of the application, meaning it was applied to none of the requests. I moved it to the beginning of the application so that it works.